### PR TITLE
Add tool for updating Retell LLM states

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@abhaybabbar/retellai-mcp-server",
+  "name": "@getsupervisor/retellai-mcp-server",
   "version": "1.0.2",
   "type": "module",
   "main": "build/index.js",
@@ -16,12 +16,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
     "dotenv": "^16.5.0",
-    "retell-sdk": "^4.28.0"
+    "retell-sdk": "^4.28.0",
+    "typescript": "^5.8.3"
   },
   "bin": {
-    "@abhaybabbar/retellai-mcp-server": "build/index.js"
+    "@getsupervisor/retellai-mcp-server": "build/index.js"
   },
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/abhaybabbar/retellai-mcp-server.git"

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -747,9 +747,40 @@ export const UpdateRetellLLMInputSchema = z.object({
   knowledge_base_ids: z.array(z.string()).optional(),
 });
 
+// Schema para estados de Retell LLM, según LlmUpdateParams.State
+const RetellLLMStateSchema = z.object({
+  name: z.string(),
+  state_prompt: z.string(),
+  edges: z
+    .array(
+      z.object({
+        destination_state_name: z.string(),
+        description: z.string(),
+        parameters: z
+          .object({
+            type: z.literal("object"),
+            properties: z.record(z.any()),
+            required: z.array(z.string()),
+          })
+          .optional(),
+      })
+    )
+    .optional(),
+  tools: z
+    .array(
+      z.object({
+        type: z.string(),
+        name: z.string(),
+        description: z.string(),
+        parameters: z.record(z.any()).optional(),
+      })
+    )
+    .optional(),
+});
+
 export const UpdateRetellLLMStatesInputSchema = z.object({
   llmId: z.string().describe("The ID of the Retell LLM to update"),
-  states: z.array(z.record(z.any())).min(1).describe("States of the LLM"),
+  states: z.array(RetellLLMStateSchema).min(1).describe("States of the LLM"),
   startingState: z
     .string()
     .describe("Name of the starting state. Must match one of the state names"),

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -747,6 +747,14 @@ export const UpdateRetellLLMInputSchema = z.object({
   knowledge_base_ids: z.array(z.string()).optional(),
 });
 
+export const UpdateRetellLLMStatesInputSchema = z.object({
+  llmId: z.string().describe("The ID of the Retell LLM to update"),
+  states: z.array(z.record(z.any())).min(1).describe("States of the LLM"),
+  startingState: z
+    .string()
+    .describe("Name of the starting state. Must match one of the state names"),
+});
+
 export const RetellLLMOutputSchema = z.object({
   llm_id: z.string(),
   version: z.number(),

--- a/src/tools/retell-llm.ts
+++ b/src/tools/retell-llm.ts
@@ -5,10 +5,12 @@ import {
   CreateRetellLLMInputSchema,
   GetRetellLLMInputSchema,
   UpdateRetellLLMInputSchema,
+  UpdateRetellLLMStatesInputSchema,
 } from "../schemas/index.js";
 import {
   transformRetellLLMInput,
   transformUpdateRetellLLMInput,
+  transformUpdateRetellLLMStatesInput,
   transformRetellLLMOutput,
 } from "../transformers/index.js";
 import { createToolHandler } from "./utils.js";
@@ -70,6 +72,23 @@ export const registerRetellLLMTools = (
         console.error(`Error updating Retell LLM: ${error.message}`);
         throw error;
       }
+    })
+  );
+
+  server.tool(
+    "update_retell_llm_states",
+    "Updates states and starting state of a Retell LLM",
+    UpdateRetellLLMStatesInputSchema.shape,
+    createToolHandler(async (data) => {
+      const stateNames = data.states.map((s: any) => s.name);
+      if (!stateNames.includes(data.startingState)) {
+        throw new Error(
+          "startingState must match one of the provided state names"
+        );
+      }
+      const updateDto = transformUpdateRetellLLMStatesInput(data);
+      const updatedLLM = await retellClient.llm.update(data.llmId, updateDto);
+      return transformRetellLLMOutput(updatedLLM);
     })
   );
 

--- a/src/tools/retell-llm.ts
+++ b/src/tools/retell-llm.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import Retell from "retell-sdk";
+import type { LlmUpdateParams } from "retell-sdk/resources/llm.js";
 
 import {
   CreateRetellLLMInputSchema,
@@ -86,7 +87,9 @@ export const registerRetellLLMTools = (
           "startingState must match one of the provided state names"
         );
       }
-      const updateDto = transformUpdateRetellLLMStatesInput(data);
+      const updateDto = transformUpdateRetellLLMStatesInput(
+        data
+      ) as LlmUpdateParams;
       const updatedLLM = await retellClient.llm.update(data.llmId, updateDto);
       return transformRetellLLMOutput(updatedLLM);
     })

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -11,6 +11,7 @@ import {
   UpdateAgentInputSchema,
   CreateRetellLLMInputSchema,
   UpdateRetellLLMInputSchema,
+  UpdateRetellLLMStatesInputSchema,
   RetellLLMOutputSchema,
   ListCallsInputSchema,
   UpdateCallInputSchema,
@@ -350,6 +351,15 @@ export function transformUpdateRetellLLMInput(
     updateData.knowledge_base_ids = input.knowledge_base_ids;
 
   return updateData;
+}
+
+export function transformUpdateRetellLLMStatesInput(
+  input: z.infer<typeof UpdateRetellLLMStatesInputSchema>
+) {
+  return {
+    states: input.states,
+    starting_state: input.startingState,
+  };
 }
 
 export function transformRetellLLMOutput(

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import {
   CreatePhoneCallInputSchema,
   CreateWebCallInputSchema,
-  CallOutputSchema,
   AgentOutputSchema,
   PhoneNumberOutputSchema,
   VoiceOutputSchema,


### PR DESCRIPTION
## Summary
- remove unused CLI script
- add schema and transformer for updating LLM states
- expose `update_retell_llm_states` tool in the Retell LLM toolset

## Testing
- `npm run build` *(failed: missing packages and network access)*

------
https://chatgpt.com/codex/tasks/task_b_686c393dfad0832dbf37c49d6c2085eb